### PR TITLE
add scenario to executed scheduller in data processing

### DIFF
--- a/src/test/java/elements/DataProcessingElement.java
+++ b/src/test/java/elements/DataProcessingElement.java
@@ -74,9 +74,6 @@ public class DataProcessingElement {
     @FindBy(css = "#search_data_tabular0_separator")
     protected WebElement DATAPROCESSING_SEPARATOR_SEARCHBOX_TEXT;
 
-    @FindBy(css = ".menu-toggle.text-uppercase.toggled[aria-controls='collapseOne_1']")
-    protected WebElement DATAPROCESSING_QUERY_INFORMATION_BUTTON;
-
     @FindBy(xpath = "//option[normalize-space()='Default']")
     protected WebElement DATAPROCESSING_OPTION_DEFAULT_DROPDOWN;
 
@@ -153,10 +150,21 @@ public class DataProcessingElement {
     @FindBy(xpath = "//h5[normalize-space()='Process failed']")
     protected WebElement DATAPROCESSING_POPUP_MESSAGE_TXT;
 
+    
     /**
      * @SCHEDULLER
+     * @DESCRIPTION this func to hands-on element executed date picker
      */
 
+     @FindBy(css = ".menu-toggle.text-uppercase.toggled[aria-controls='collapseOne_1']")
+     protected WebElement DATAPROCESSING_QUERY_INFORMATION_BUTTON;
+
      @FindBy(id = "selectedSchedulerMode")
-     protected WebElement DATAPROCESSING_SELECTED_SCHEDULLER_TXT;
+     protected WebElement DATAPROCESSING_SELECTED_SCHEDULER_DROPDOWN;
+
+     @FindBy(id = "start_time")
+     protected WebElement DATAPROCESSING_START_TIME_DATEPICKER;
+
+     @FindBy(css = "div[id='dtp_ZMQiK'] button[class='dtp-btn-ok btn btn-flat btn-sm']")
+     protected WebElement DATAPROCESSING_DATEPICKER_OKE_BUTTON;
 }

--- a/src/test/java/elements/DataProcessingElement.java
+++ b/src/test/java/elements/DataProcessingElement.java
@@ -156,8 +156,14 @@ public class DataProcessingElement {
      * @DESCRIPTION this func to hands-on element executed date picker
      */
 
-     @FindBy(css = ".menu-toggle.text-uppercase.toggled[aria-controls='collapseOne_1']")
+     @FindBy(xpath = "//*[text()='Close']")
+     protected WebElement DATAPROCESSING_CLOSE_QUERY_EDITOR_BUTTON;
+
+     @FindBy(id = "headingOne_1")
      protected WebElement DATAPROCESSING_QUERY_INFORMATION_BUTTON;
+
+     @FindBy(css = "label[for='chck0']")
+     protected WebElement DATAPROCESSING_SPAWN_SCHEDULER_BUTTON;
 
      @FindBy(id = "selectedSchedulerMode")
      protected WebElement DATAPROCESSING_SELECTED_SCHEDULER_DROPDOWN;

--- a/src/test/java/helper/TestInstrument.java
+++ b/src/test/java/helper/TestInstrument.java
@@ -83,6 +83,17 @@ public class TestInstrument {
         }
     }
 
+    public static Boolean clickCheckBox(WebElement locator){
+        Boolean target = locator.isDisplayed();
+        if(target.equals(true)){
+            locator.click();
+        } else {
+            throw new Error("Check this a locator : " + locator);
+        }
+        
+        return target;
+    }
+
     public static WebElement clickButtonByKeys(WebElement locator) {
         if(locator.equals(null)){
             throw new ElementNotInteractableException("please check this element locator : " + locator);

--- a/src/test/java/helper/TestInstrument.java
+++ b/src/test/java/helper/TestInstrument.java
@@ -128,8 +128,9 @@ public class TestInstrument {
         } else {
             if(isElementExist(elementLocator, timeout)){
                 action = new Actions(driver);
-                action.moveToElement(elementLocator);
-                action.build().perform();
+                action.moveToElement(elementLocator)
+                    .build()
+                    .perform();
             }
         }
     }

--- a/src/test/java/pages/DataProcessingPage.java
+++ b/src/test/java/pages/DataProcessingPage.java
@@ -205,19 +205,34 @@ public class DataProcessingPage extends DataProcessingElement {
     }
 
     /**
+     * {@summary}
      * this for executed scheduler
      */
 
+     public void closeQueryEditor(){
+        if(isElementExist(DATAPROCESSING_CLOSE_QUERY_EDITOR_BUTTON, 4)){
+            clickButton(DATAPROCESSING_CLOSE_QUERY_EDITOR_BUTTON);
+        }
+     }
+
      public void clickSectionQueryInformation(){
+        closeQueryEditor();
+        scrollIntoView(DATAPROCESSING_QUERY_INFORMATION_BUTTON, driver, 4);
         if(isElementExist(DATAPROCESSING_QUERY_INFORMATION_BUTTON, 2)){
             clickButton(DATAPROCESSING_QUERY_INFORMATION_BUTTON);
         }
      }
 
-     public void chooseScheduler(String value){
+     public void spawnScheduler(){
+        scrollIntoElement(DATAPROCESSING_SPAWN_SCHEDULER_BUTTON, 4);
+        clickButton(DATAPROCESSING_SPAWN_SCHEDULER_BUTTON);
+     }
+
+     public void chooseScheduler(String TimeScheduler){
         if(isElementExist(DATAPROCESSING_SELECTED_SCHEDULER_DROPDOWN, 4)){
             try {
-                selectDropDownValue(DATAPROCESSING_SELECTED_SCHEDULER_DROPDOWN, Dropdown.VALUE.toString(), value);
+                spawnScheduler();
+                selectDropDownValue(DATAPROCESSING_SELECTED_SCHEDULER_DROPDOWN, Dropdown.VALUE.toString(), TimeScheduler);
             } catch (ElementClickInterceptedException e) {
                 e.printStackTrace();
             }

--- a/src/test/java/pages/DataProcessingPage.java
+++ b/src/test/java/pages/DataProcessingPage.java
@@ -1,10 +1,12 @@
 package pages;
 
+import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.pagefactory.AjaxElementLocatorFactory;
 
 import elements.DataProcessingElement;
+import helper.Dropdown;
 
 import static helper.TestInstrument.*;
 
@@ -201,4 +203,37 @@ public class DataProcessingPage extends DataProcessingElement {
             assertEquals(expected, actual);
         }
     }
+
+    /**
+     * this for executed scheduler
+     */
+
+     public void clickSectionQueryInformation(){
+        if(isElementExist(DATAPROCESSING_QUERY_INFORMATION_BUTTON, 2)){
+            clickButton(DATAPROCESSING_QUERY_INFORMATION_BUTTON);
+        }
+     }
+
+     public void chooseScheduler(String value){
+        if(isElementExist(DATAPROCESSING_SELECTED_SCHEDULER_DROPDOWN, 4)){
+            try {
+                selectDropDownValue(DATAPROCESSING_SELECTED_SCHEDULER_DROPDOWN, Dropdown.VALUE.toString(), value);
+            } catch (ElementClickInterceptedException e) {
+                e.printStackTrace();
+            }
+        }
+     }
+
+     public void setSchedulerToday(){
+        if(isElementExist(DATAPROCESSING_START_TIME_DATEPICKER, 6)){
+            try {
+                getCurrentDay();
+                if(isElementExist(DATAPROCESSING_DATEPICKER_OKE_BUTTON, 6)){
+                    clickButton(DATAPROCESSING_DATEPICKER_OKE_BUTTON);
+                }
+            } catch (ElementClickInterceptedException e) {
+                throw new Error("please check element" + e.getCause());
+            }
+        }
+     }
 }

--- a/src/test/java/stepdefinitions/ExecutedScheduler.java
+++ b/src/test/java/stepdefinitions/ExecutedScheduler.java
@@ -1,0 +1,22 @@
+package stepdefinitions;
+
+import helper.TestInstrument;
+import io.cucumber.java8.En;
+
+public class ExecutedScheduler extends TestInstrument implements En {
+    
+    public ExecutedScheduler(){
+
+        And("^user click on section query information tab$", () -> {
+            paques.dataProcessingPage().clickSectionQueryInformation();
+        });
+
+        When("^user set scheduller from time \"([^\"]*)\"$$", (String TimeScheduler) -> {
+            paques.dataProcessingPage().chooseScheduler(TimeScheduler);
+        });
+
+        And("^user set scheduler time from today$", () -> {
+            paques.dataProcessingPage().setSchedulerToday();
+        });
+    }
+}

--- a/src/test/java/stepdefinitions/ExecutedScheduler.java
+++ b/src/test/java/stepdefinitions/ExecutedScheduler.java
@@ -11,7 +11,7 @@ public class ExecutedScheduler extends TestInstrument implements En {
             paques.dataProcessingPage().clickSectionQueryInformation();
         });
 
-        When("^user set scheduller from time \"([^\"]*)\"$$", (String TimeScheduler) -> {
+        When("^user set scheduller from time \"([^\"]*)\" minutes$", (String TimeScheduler) -> {
             paques.dataProcessingPage().chooseScheduler(TimeScheduler);
         });
 

--- a/src/test/resources/features/DataProcessing/TC03_EditMetaData.feature
+++ b/src/test/resources/features/DataProcessing/TC03_EditMetaData.feature
@@ -1,21 +1,21 @@
 @edit-metadata
 Feature: Edit Metadata
 
-    @apps @positive-scenario
+    @regression @positive-scenario
     Scenario: user edit metadata
-    Given user login with "PDS_NONADMIN"
-    And user click on data processing
-    And user create query using query command with "Data Tabular"
-    And user filled in filepath as "Brenda_Test/paques_data.csv" in section command property
-    And user filled in separator as "," in section command property
-    And user choose "First Row as a Header" in section command property
-    And user filled in row limit as "20" in section command property
-    When user click on run button at navbar
-    Then user see first row as a header in datatable
-    And user click metadata setting
-    When user check Date time flag to yes
-    And user click on save button at navbar
-    Then user should be able to see a popup message "Process Completed"
+        Given user login with "PDS_NONADMIN"
+        And user click on data processing
+        And user create query using query command with "Data Tabular"
+        And user filled in filepath as "Brenda_Test/paques_data.csv" in section command property
+        And user filled in separator as "," in section command property
+        And user choose "First Row as a Header" in section command property
+        And user filled in row limit as "20" in section command property
+        When user click on run button at navbar
+        Then user see first row as a header in datatable
+        And user click metadata setting
+        When user check Date time flag to yes
+        And user click on save button at navbar
+        Then user should be able to see a popup message "Process Completed"
 
 #     @regression @negative-scenario
 #     Scenario: Edit Metadata not match with data

--- a/src/test/resources/features/DataProcessing/TC04_AddScheduller.feature
+++ b/src/test/resources/features/DataProcessing/TC04_AddScheduller.feature
@@ -1,8 +1,8 @@
-@Scheduller
+@Scheduler
 Feature: Executed Scheduller
 
-    ## Pre-Condition
-    Background:
+    @sanity @positive-Scenario
+    Scenario: user want to executed scheduller in PDS Application
         Given user login with "PDS_NONADMIN"
         And user click on data processing
         And user create query using query command with "Data Tabular"
@@ -12,11 +12,8 @@ Feature: Executed Scheduller
         And user filled in row limit as "20" in section command property
         When user click on run button at navbar
         Then user see first row as a header in datatable
-
-    @sanity @positive-Scenario
-    Scenario: user want to executed scheduller in PDS Application
         And user click on section query information tab
-        When user set scheduller from time "5 minutes"
+        When user set scheduller from time "5" minutes
         And user set scheduler time from today
         And user click on save button at navbar
         Then user should be able to see a message "Process Completed" will be displayed

--- a/src/test/resources/features/DataProcessing/TC04_AddScheduller.feature
+++ b/src/test/resources/features/DataProcessing/TC04_AddScheduller.feature
@@ -1,0 +1,22 @@
+@Scheduller
+Feature: Executed Scheduller
+
+    ## Pre-Condition
+    Background:
+        Given user login with "PDS_NONADMIN"
+        And user click on data processing
+        And user create query using query command with "Data Tabular"
+        And user filled in filepath as "Brenda_Test/paques_data.csv" in section command property
+        And user filled in separator as "," in section command property
+        And user choose "First Row as a Header" in section command property
+        And user filled in row limit as "20" in section command property
+        When user click on run button at navbar
+        Then user see first row as a header in datatable
+
+    @sanity @positive-Scenario
+    Scenario: user want to executed scheduller in PDS Application
+        And user click on section query information tab
+        When user set scheduller from time "5 minutes"
+        And user set scheduler time from today
+        And user click on save button at navbar
+        Then user success to set the query will be executed automatically

--- a/src/test/resources/features/DataProcessing/TC04_AddScheduller.feature
+++ b/src/test/resources/features/DataProcessing/TC04_AddScheduller.feature
@@ -19,4 +19,4 @@ Feature: Executed Scheduller
         When user set scheduller from time "5 minutes"
         And user set scheduler time from today
         And user click on save button at navbar
-        Then user success to set the query will be executed automatically
+        Then user should be able to see a message "Process Completed" will be displayed


### PR DESCRIPTION
NB: `R` mean required. Remove unused section

## Type of changes(R)
- [x] Feature
- [ ] Refactor
- [ ] Script
- [ ] Test
- [ ] Other

## Testcases(R)
```
## Pre-Condition
   ` Background`:
        Given user login with "PDS_NONADMIN"
        And user click on data processing
        And user create query using query command with "Data Tabular"
        And user filled in filepath as "Brenda_Test/paques_data.csv" in section command property
        And user filled in separator as "," in section command property
        And user choose "First Row as a Header" in section command property
        And user filled in row limit as "20" in section command property
        When user click on run button at navbar
        Then user see first row as a header in data table

    `Scenario`: user want to executed scheduler in PDS Application

        And user click on section query information tab
        When user set scheduler from time "5 minutes"
        And user set scheduler time from today
        And user click on save button at navbar
        Then user success to set the query will be executed automatically
```